### PR TITLE
fixed severity icons

### DIFF
--- a/language.py
+++ b/language.py
@@ -31,7 +31,7 @@ from .util import (
 
         ValidationError,
     )
-from .dlg import Hint
+from .dlg import Hint, SEVERITY_MAP
 from .dlg import PanelLog, SEVERITY_ERR
 from .book import EditorDoc
 #from .tree import TreeMan  # imported on access
@@ -1013,7 +1013,8 @@ class DiagnosticsMan:
                     text = ''.join([pre, severity_short, mid, code, post, d.message])
                     msg_lines.append(text)
                     filename = os.path.basename(ed.get_filename())
-                    self.logger.log_str(f"[{filename}:{d.range.start.line+1}] {text}", type_="Errors", severity=SEVERITY_ERR)
+                    self.logger.log_str(f"[{filename}:{d.range.start.line+1}] {text}",
+                                        type_="Errors", severity=SEVERITY_MAP[d.severity])
 
                 # gather err ranges
                 for d in diags:


### PR DESCRIPTION
SEVERITY_ERR replaced with SEVERITY_MAP[d.severity]
so all icons now supported, not only ERR.

![image](https://user-images.githubusercontent.com/275333/168441740-f5e8bdea-894f-477a-87c2-9dccf9ec7cf6.png)
