### PR TITLE
added support for "workspace/didChangeConfiguration"

### DIFF
--- a/language.py
+++ b/language.py
@@ -31,7 +31,7 @@ from .util import (
 
         ValidationError,
     )
-from .dlg import Hint
+from .dlg import Hint, SEVERITY_MAP
 from .dlg import PanelLog, SEVERITY_ERR
 from .book import EditorDoc
 #from .tree import TreeMan  # imported on access
@@ -1013,7 +1013,8 @@ class DiagnosticsMan:
                     text = ''.join([pre, severity_short, mid, code, post, d.message])
                     msg_lines.append(text)
                     filename = os.path.basename(ed.get_filename())
-                    self.logger.log_str(f"[{filename}:{d.range.start.line+1}] {text}", type_="Errors", severity=SEVERITY_ERR)
+                    self.logger.log_str(f"[{filename}:{d.range.start.line+1}] {text}",
+                                        type_="Errors", severity=SEVERITY_MAP[d.severity])
 
                 # gather err ranges
                 for d in diags:

--- a/language.py
+++ b/language.py
@@ -31,7 +31,7 @@ from .util import (
 
         ValidationError,
     )
-from .dlg import Hint, SEVERITY_MAP
+from .dlg import Hint
 from .dlg import PanelLog, SEVERITY_ERR
 from .book import EditorDoc
 #from .tree import TreeMan  # imported on access
@@ -1014,8 +1014,7 @@ class DiagnosticsMan:
                     text = ''.join([pre, severity_short, mid, code, post, d.message])
                     msg_lines.append(text)
                     filename = os.path.basename(ed.get_filename())
-                    self.logger.log_str(f"[{filename}:{d.range.start.line+1}] {text}",
-                                        type_="Errors", severity=SEVERITY_MAP[d.severity])
+                    self.logger.log_str(f"[{filename}:{d.range.start.line+1}] {text}", type_="Errors", severity=SEVERITY_ERR)
 
                 # gather err ranges
                 for d in diags:

--- a/language.py
+++ b/language.py
@@ -175,6 +175,7 @@ class Language:
                 root_uri=root_uri,
                 workspace_folders=self.workspace_folders,
                 process_id=os.getpid(),
+                settings=self._cfg["settings"]
             )
             self._start_server()
         return self._client

--- a/sansio_lsp_client/client.py
+++ b/sansio_lsp_client/client.py
@@ -191,6 +191,7 @@ class Client:
         root_uri: t.Optional[str] = None,
         workspace_folders: t.Optional[t.List[WorkspaceFolder]] = None,
         trace: str = "off",
+        settings = {},
     ) -> None:
         self._state = ClientState.NOT_INITIALIZED
 
@@ -229,6 +230,9 @@ class Client:
             },
         )
         self._state = ClientState.WAITING_FOR_INITIALIZED
+
+        # prepare configuration for sending via "workspace/didChangeConfiguration"
+        self.settings = settings
 
     @property
     def state(self) -> ClientState:
@@ -277,6 +281,9 @@ class Client:
         if request.method == "initialize":
             assert self._state == ClientState.WAITING_FOR_INITIALIZED
             self._send_notification("initialized", params={}) # 'gopls' doesnt recognise 'None' 'params'
+            self._send_notification("workspace/didChangeConfiguration", params={
+                "settings": self.settings
+            })
             event = Initialized.parse_obj(response.result)
             self._state = ClientState.NORMAL
 


### PR DESCRIPTION
in cuda_lsp readme.txt there is a section about "Server-specific options" but i could not get them to work for me.
in readme file we see two places for server-specific settings:

a) settings/lsp_python.json ("settings" subkey)
b) project config myname.cuda-proj-lsp

example settings for lsp_python.json:
```json
"settings": {
        "pylsp": {
            "plugins": {
                "flake8": {
                    "enabled": true,
                    "ignore": ["F403","F405","E101","E228","E501","E271","E272","E231","E203"]
                },
                "pyflakes": {
                    "enabled": false,
                },
                "pycodestyle": {
                    "enabled": false,
                },
                "mccabe": {
                    "enabled": true,
                },
            }
        }
      }
```

I look into code and could not find workspace/didChangeConfiguration request.
I added it by myself.

after "initialized" request we immediately send "didChangeConfiguration" like in [SublimeLSP code](https://github.com/sublimelsp/LSP/blob/de0ef67befd7d2e813ebe7fcabacdb143ff9e535/plugin/core/sessions.py#L1307).
after that SublimeLSP do it everytime when settings are changed by the user, but we are keeping things simple and do it one time - only on initialization. Therefore user must restart CudaText when he changes settings.

BTW: if settings will be in .cuda-proj-lsp file they will have higher priority then those in "settings/lsp_python.json" file.