### PR TITLE
fixed CompletionItemTag not being a list

### DIFF
--- a/sansio_lsp_client/structs.py
+++ b/sansio_lsp_client/structs.py
@@ -206,7 +206,7 @@ class CompletionItemTag(enum.IntEnum):
 class CompletionItem(BaseModel):
     label: str
     kind: t.Optional[CompletionItemKind]
-    tags: t.Optional[CompletionItemTag]
+    tags: t.Optional[t.List[CompletionItemTag]]
     detail: t.Optional[str] # human string, line symbol info -- None in C#
     documentation: t.Union[str, MarkupContent, None]
     deprecated: t.Optional[bool] # is deprecated


### PR DESCRIPTION
according to [specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/) CompletionItemTag type must be a list.

```js
/**
* Tags for this completion item.
*
* @since 3.15.0
*/
tags?: CompletionItemTag[];
```

this PR fixes completionlist not showing when CompletionItemTag is present in a response from lsp server.

for example, typescript-language-server sends this tag and it IS a list, not just integer:
```json
 "tags": [1]
```