### PR TITLE
fixed double snippet triggering

### DIFF
--- a/language.py
+++ b/language.py
@@ -106,6 +106,7 @@ class Language:
     def __init__(self, cfg, cmds=None, lintstr='', underline_style=None, state=None):
         self._shutting_down = None  # scheduled shutdown when not yet initialized
 
+        self._last_complete = None
         self._cfg = cfg
         self._caret_cmds = cmds # {caption -> callable}
 
@@ -650,9 +651,12 @@ class Language:
             return True
 
     def on_snippet(self, ed_self, snippet_id, snippet_text): # completion callback
-        if snippet_id == SNIP_ID:
+        if snippet_id == SNIP_ID and self._last_complete:
             compl, message_id, items = self._last_complete
             compl.do_complete(message_id, snippet_text, items)
+            self._last_complete = None
+            return True
+        return False
 
 
     def on_hover(self, eddoc, caret):

--- a/lsp.py
+++ b/lsp.py
@@ -376,7 +376,8 @@ class Command:
         """ for Editor.complete_alt()
         """
         for lang in self._langs.values():
-            lang.on_snippet(ed_self, snippet_id, snippet_text)
+            if lang.on_snippet(ed_self, snippet_id, snippet_text):
+                break
 
     def on_mouse_stop(self, ed_self, x, y):
         if not opt_enable_mouse_hover:      return


### PR DESCRIPTION
fixed this bug https://github.com/halfbrained/cuda_lsp/issues/114

> заметил, что автодополнение для javascript работает странно.
> Вот к примеру пишу "console." далее нажимаю ctrl + пробел и выбираю функцию log. В итоге получаю следующее "console.log(log())". И такое поведение везде.

this happens because we have this loop:
```python
def on_snippet(self, ed_self, snippet_id, snippet_text):
  for lang in self._langs.values():
    lang.on_snippet(ed_self, snippet_id, snippet_text)
```

and _langs is populated with two identical objects:

![image](https://user-images.githubusercontent.com/275333/169226145-225b9bc3-5aea-4a5e-be7b-8a2d49412594.png)

i think it because according to [CudaText wiki](https://wiki.freepascal.org/CudaText_plugins#LSP_server_for_JavaScript.2FReactJS) user has configured two lexers for one lsp server: 
```json
"JavaScript": "javascript",
"JavaScript Babel": "javascriptreact"
```

i don't know if it meant to be like that or not. i just fixed the problem like this:
we break from the loop if on_snipped was already processed by another `lang`.