### PR TITLE
fixed Hint and Autocompletion bugs

### DIFF
--- a/dlg.py
+++ b/dlg.py
@@ -114,7 +114,9 @@ class Hint:
     # language - from deprecated 'MarkedString'
     @classmethod
     def show(cls, text, caret, cursor_loc_start, markupkind=None, language=None, caret_cmds=None):
-        import html
+
+        if not ed.get_prop(PROP_FOCUSED):
+            return # show Hint only if editor is focused (and not autocompletion dialog)
 
         if not text:
             return
@@ -140,6 +142,7 @@ class Hint:
         try:
             if markupkind == MarkupKind.MARKDOWN:
                 cls.ed.set_prop(PROP_LEXER_FILE, 'Markdown')
+                import html
                 text = html.unescape(text)
                 text = cls.unescape_bslash(text)
             else:
@@ -236,7 +239,9 @@ class Hint:
     @classmethod
     def hide_check_timer(cls, tag='', info=''):
         # hide if not over dialog  and  cursor moved at least ~15px
-        if not is_mouse_in_form(cls.h)  and  cursor_dist(cls.cursor_pos) > cls.cursor_margin:
+        if not cls.is_visible(): #stop the timer if dialog was already closed (could be closed by autocompletion)
+            timer_proc(TIMER_STOP, Hint.hide_check_timer, 250, tag='')
+        elif not is_mouse_in_form(cls.h) and cursor_dist(cls.cursor_pos) > cls.cursor_margin:
             timer_proc(TIMER_STOP, Hint.hide_check_timer, 250, tag='')
 
             cls.hide()

--- a/readme/history.txt
+++ b/readme/history.txt
@@ -1,3 +1,5 @@
+2022.06.09
+- fix: hover hint dialog and autocompletion dialog could show up at the same time causing various bugs (by @veksha)
 
 2022.05.20
 + add: Escape-key in Hover dialog closes the dialog (by Alexey T.)


### PR DESCRIPTION
I wanted to eliminate situations like this, sometimes both dialogs will open:

![1](https://user-images.githubusercontent.com/275333/172907184-b1036aaa-d33b-421b-a143-85b3768a11af.png)

reproduce: hold Control key, then moving mouse to keyword, then pressing space. (it could trigger hover hint dialog and autocompletion at the same time)

not looking very beautiful, and it has bugs.

1.
    now if you only move your mouse a little - both of dialogs will get closed, which is annoying.
    (hint dialog on its closing phase calls `ed.focus()` and this is the reason why autocompletion dialog gets closed too, only by mouse move!) (bug)

2.
    similar bug is when you press ctrl-space when hint dialog was already opened.
    even though hint dialog will close automatically before autocompletion will show up, its **timer will not stop!**(timer for mouse move detection)
    now move your mouse a little and **autocompletion** dialog will close! (strange behaviour, not what we want)

3.
    also, you can press ctrl-space to show autocompletion and THEN invoke hint dialog by custom keypress.
    same thing. two dialogs at the same time and same problems.

I decided that no one will ever want these two dialogs to be opened at the same time. this only causing problems.

