### PR TITLE
fixed lsp ResponseMessage (result is REQUIRED on success)

### DIFF
--- a/sansio_lsp_client/io_handler.py
+++ b/sansio_lsp_client/io_handler.py
@@ -60,6 +60,14 @@ def _make_response(
         content["result"] = result
     if error is not None:
         content["error"] = error
+    elif result is None:
+        content["result"] = None # "result": null
+
+     #                    content["result"]
+	 # The result of a request. This member is REQUIRED on success.
+	 # This member MUST NOT exist if there was an error invoking the method.
+	 #
+
     encoded_content = json.dumps(content).encode(encoding)
 
     # Write the headers to the request body


### PR DESCRIPTION
According to [LSP specs](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/) "result" member of ResponseMessage is required on success.

success response
before patch: `{"jsonrpc":"2.0","id":1}.`
after patch: `{"jsonrpc":"2.0","id":1,"result":null}.`

