### PR TITLE
enable simultaneous use of `tcp_port` and `cmd_*`

### DIFF
--- a/language.py
+++ b/language.py
@@ -267,6 +267,8 @@ class Language:
 
         # if config has tcp port - connect to it
         if self._tcp_port and type(self._tcp_port) == int:
+            if self._server_cmd:
+                connect_via_stdin()
             connect_via_tcp()
         # not port - create stdio-process
         else:


### PR DESCRIPTION
```json
{
    "name": "PHP",
    "lexers": {
        "PHP": "php"
    },
    "cmd_windows": ["php","D:\\programm\\php\\php-language-server\\bin\\php-language-server.php","--tcp-server=127.0.0.1:12345"],
    "tcp_port": 12345,
    "log_stderr": true,
    "settings": {

    }
}
```

![image](https://user-images.githubusercontent.com/275333/174028372-7a3ad81d-43d7-4b06-a14e-96b1bff380eb.png)

works