### PR TITLE
fixed: decor icons were not clearing

### DIFF
--- a/language.py
+++ b/language.py
@@ -1058,7 +1058,7 @@ class DiagnosticsMan:
                     if decor_severity == 9:
                         decor_severity = DIAG_DEFAULT_SEVERITY
                     tooltip = chr(1)+text if api_ver >= '1.0.427' else ''
-                    ed.decor(DECOR_SET, line=nline, image=decor_im_map[decor_severity], text=tooltip)
+                    ed.decor(DECOR_SET, line=nline, image=decor_im_map[decor_severity], text=tooltip, tag=DIAG_BM_TAG)
                 else:
                     text = '\n'.join(msg_lines)
                     ed.bookmark(BOOKMARK_SET, nline=nline, nkind=kind, text=text, tag=DIAG_BM_TAG)


### PR DESCRIPTION
this is code of clearing decor/bookmarks.
```python
        if self._linttype == DiagnosticsMan.LINT_DECOR:
            ed.decor(DECOR_DELETE_BY_TAG, tag=DIAG_BM_TAG)
        else:
            ed.bookmark(BOOKMARK_DELETE_BY_TAG, 0, tag=DIAG_BM_TAG)
```
as you can see they are removed by  **tag** (DIAG_BM_TAG).
but decor icons were not created with tag.