### PR TITLE
additional spaces were generated at the end of line (fixed)

### DIFF
--- a/language.py
+++ b/language.py
@@ -1451,6 +1451,7 @@ class CompletionMan:
         padding = ' '*(x2-len(_line_txt)) if len(_line_txt) < x2 else ''
         if padding: # to support virtual caret
             ed.insert(x1,y1, padding)
+            x2 += len(padding)
         new_caret = ed.replace(x1,y1,x2,y2, text + ('()' if (is_callable and not is_bracket_follows) else ''))
         # move caret at ~end of inserted text
         if new_caret:


### PR DESCRIPTION
1. put caret on virtual position (with "Right" key)
2. autocomplete
3. see additional spaces  at the end of the line

fixed.

before:

![image](https://user-images.githubusercontent.com/275333/190851649-4c30821a-a505-4db2-9e1a-6fc782e6909f.png)

after:

![image](https://user-images.githubusercontent.com/275333/190851666-d014fbb7-e8f9-4a1b-9e81-022d4e7f6d0d.png)
