### PR TITLE
fixed wrong msg count on LSP overlay (when count drops to 0)

### DIFF
--- a/dlg.py
+++ b/dlg.py
@@ -611,6 +611,7 @@ class PanelLog:
         self._msgs.clear()
         self._update_memo()
         self._update_counts()
+        self._update_sidebar()
 
     def toggle_wrap(self):
         self._is_wrap = not self._is_wrap
@@ -622,7 +623,8 @@ class PanelLog:
 
     def _update_sidebar(self):
         if self._h_btn_sidebar:
-            button_proc(self._h_btn_sidebar, BTN_SET_OVERLAY, str(len(self._msgs)))
+            overlay_text = str(len(self._msgs)) if len(self._msgs) > 0 else '' # clear if zero
+            button_proc(self._h_btn_sidebar, BTN_SET_OVERLAY, overlay_text)
 
     def _append_memo_msg(self, msg):
         _nline = self._memo_pos[1]


### PR DESCRIPTION
when msg count **drops to 0** Cuda_LSP is showing last msg count in overlay.

before: ![image](https://user-images.githubusercontent.com/275333/191269448-3c9d9a9b-f7d7-45c3-a2e0-fed952ea7090.png)
after:  ![image](https://user-images.githubusercontent.com/275333/191269530-3a3bd563-6151-4ba2-801e-377cd3c00c92.png)

