### PR TITLE
create lines for additionalTextEdits if needed

### DIFF
--- a/book.py
+++ b/book.py
@@ -224,6 +224,10 @@ class EditorDoc:
     #def apply_edit(ed: Editor, edit: TextEdit):
     def apply_edit(ed, edit):
         x1,y1,x2,y2 = EditorDoc.range2carets(edit.range)
+        
+        while ed.get_line_count() <= y2:
+            ed.set_text_line(-2, '')
+        
         if x1==x2 and y1==y2:
             #NOTE: need 'insert' because cant `replace()'` beyond text end
             ed.insert(x1,y1, edit.newText)


### PR DESCRIPTION
second part of https://github.com/CudaText-addons/cuda_lsp/issues/32

before:
![image](https://user-images.githubusercontent.com/275333/191397655-03c2290d-f534-44f3-b0d7-029ab9ffd3db.png)

after:
![image](https://user-images.githubusercontent.com/275333/191397741-499f0811-63a8-4a3e-8b9c-3849d1d4913a.png)

NOTE: "include" statement is inserted below the text: this is clangd bug, in Sublime Text same situation.