### PR TITLE
black icons fix #4327

### DIFF
--- a/language.py
+++ b/language.py
@@ -580,6 +580,10 @@ class Language:
 
 
     def on_close(self, eddoc):
+        # clean up diagnostics img dictionary
+        h_ed = eddoc.ed.get_prop(PROP_HANDLE_SELF)
+        self.diagnostics_man._decor_serverity_ims.pop(h_ed, None)
+
         if self.client.is_initialized:
             opts = self.scfg.method_opts(METHOD_DID_CLOSE, eddoc)
             if opts is not None  and  eddoc.lang is not None: # lang check -- is opened


### PR DESCRIPTION
This PR will fix https://github.com/Alexey-T/CudaText/issues/4327 issue.

Black icons can still sometimes appear, but only if you open/close/open/close same file very fast.
(it is a different issue! maybe Cud's event issue. events must come like this: "open/close/open/close", but they are in fact coming like this: "open/open/close/close")