### PR TITLE
fix wrong hint param highlight

### DIFF
--- a/dlg.py
+++ b/dlg.py
@@ -859,7 +859,17 @@ class SignaturesDialog:
                     cls.memo.attr(MARKERS_ADD, x=x1, y=i, len=x2-x1, color_font=cls.color_hilite, tag=1)
                     cls.param_pos = x1
                 elif isinstance(param, str):
-                    parts = re.split(r'\(|\)|,(?![^[]*\])', sig.label)
+                    # replace comma with special char (excluding ones inside square brackets)
+                    brackets = 0
+                    char_list = list(sig.label)
+                    for j,c in enumerate(char_list):
+                        if 0:pass
+                        elif c == '[':    brackets += 1
+                        elif c == ']':    brackets -= 1
+                        elif c == ',':
+                            if brackets <= 0:   char_list[j]=chr(1)
+                    
+                    parts = re.split(r'\(|\)|\x01(?![^[]*\])', ''.join(char_list))
                     pos = 0
                     skipping = True
                     skipped = -1


### PR DESCRIPTION
before and after:

![image](https://user-images.githubusercontent.com/275333/196056859-dba390b1-8990-4629-b557-f7abdff2285b.png)
![cudatext_WYdOlzsTSo](https://user-images.githubusercontent.com/275333/196056801-7014c95d-62b2-4da4-80a4-ff0b08a6316c.png)
