### PR TITLE
support sending `CompletionContext` and using `TriggerForIncompleteCompletions`

### DIFF
--- a/sansio_lsp_client/client.py
+++ b/sansio_lsp_client/client.py
@@ -97,7 +97,8 @@ CAPABILITIES = {
             },
             'completionItemKind': {
                 'valueSet': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
-            }
+            },
+            'contextSupport': True,
         },
         'hover': {
             'dynamicRegistration': True,
@@ -554,7 +555,9 @@ class Client:
         params = {}
         params.update(text_document_position.dict())
         if context is not None:
-            params.update(context.dict())
+            params.update( {
+                'context': context.dict(exclude_unset=True)
+            } )
         return self._send_request(method="textDocument/completion", params=params)
 
 # NEW #####################


### PR DESCRIPTION
LSP spec: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionContext

This will enable caching of pyright LSP server completion results.
Because without sending `CompletionContext` to server it is impossible to get "isIncomplete: false" in response from server, therefore caching on client side were not  activated.
now it works.

related issue: https://github.com/Alexey-T/CudaText/issues/4460#issuecomment-1281542117