### PR TITLE
diagnostics no longer clear logs

### DIFF
--- a/dlg.py
+++ b/dlg.py
@@ -296,6 +296,7 @@ PANEL_LOG_TAG = app_proc(PROC_GET_UNIQUE_TAG, '') # jic
 
 TYPE_MSG = 'type_msgs'
 TYPE_LOG = 'type_logs'
+TYPE_DIAG = 'type_diags'
 
 SEVERITY_ERR = 'svr_err'
 SEVERITY_WRN = 'svr_wrn'
@@ -326,6 +327,7 @@ SEVERITY_IC_PATHS = {
 PANEL_CAPTIONS = {
     TYPE_MSG:       _('Messages'),
     TYPE_LOG:       _('Logs'),
+    TYPE_DIAG:      _('Diagnostics'),
 
     SEVERITY_ERR:   _('Error'),
     SEVERITY_WRN:   _('Warning'),
@@ -611,6 +613,12 @@ class PanelLog:
             self._extra_types.add(type_)
             self._update_sb()
 
+    def clear_diagnostics(self):
+        self._msgs = [ msg for msg in self._msgs if PanelLog.type_captions.get(msg.type, msg.type) != TYPE_DIAG ]
+        self._update_memo()
+        self._update_counts()
+        self._update_sidebar()
+        
     def clear(self):
         self._msgs.clear()
         self._update_memo()

--- a/language.py
+++ b/language.py
@@ -34,7 +34,7 @@ from .util import (
 
         ValidationError,
     )
-from .dlg import Hint, SEVERITY_MAP, SignaturesDialog
+from .dlg import Hint, SEVERITY_MAP, SignaturesDialog, TYPE_DIAG
 from .dlg import PanelLog, SEVERITY_ERR, SEVERITY_LOG
 from .book import EditorDoc
 #from .tree import TreeMan  # imported on access
@@ -1104,7 +1104,7 @@ class DiagnosticsMan:
                 self.dirtys.add(uri)
 
     def _apply_diagnostics(self, ed, diag_list):
-        self.logger.clear()
+        self.logger.clear_diagnostics()
         if self._linttype  or  self._highlight_bg:
             self._clear_old(ed)
 
@@ -1147,8 +1147,8 @@ class DiagnosticsMan:
                     if not filename_added:
                         filename_added = True
                         fn = ed.get_filename()
-                        self.logger.log_str(f"File: {fn}", type_="Errors", severity=SEVERITY_MAP[d.severity])
-                    self.logger.log_str(f"Line {d.range.start.line+1}: {text}", type_="Errors", severity=SEVERITY_MAP[d.severity])
+                        self.logger.log_str(f"File: {fn}", type_=TYPE_DIAG, severity=SEVERITY_MAP[d.severity])
+                    self.logger.log_str(f"Line {d.range.start.line+1}: {text}", type_=TYPE_DIAG, severity=SEVERITY_MAP[d.severity])
 
                 # gather err ranges
                 for d in diags:


### PR DESCRIPTION
when new diagnostics data arrives from server it will now clear only (old) diagnostics in lsp memo.
other messages (like logs) will remain intact.

![image](https://user-images.githubusercontent.com/275333/196334697-1663d4e0-3b1f-4252-94a3-61417458bb00.png)
