### PR TITLE
fix infinite loop of "connection lost" kind of errors

### DIFF
--- a/language.py
+++ b/language.py
@@ -326,6 +326,9 @@ class Language:
             while self._reader:
                 try:
                     headers, header_bytes = parse_headers(self._reader)  # type: ignore
+                except ConnectionResetError as ex:
+                    print(f"{LOG_NAME}: {self.lang_str} - tcp connection lost:", ex)
+                    break
                 except Exception as ex:
                     print(f'{LOG_NAME}: {self.lang_str} - header parse error: {ex}')
                     pass;       LOG and traceback.print_exc()


### PR DESCRIPTION
fix infine loop of:
```
...
LSP: V - header parse error: [WinError 10054] Удаленный хост принудительно разорвал существующее подключение
LSP: V - header parse error: [WinError 10054] Удаленный хост принудительно разорвал существующее подключение
LSP: V - header parse error: [WinError 10054] Удаленный хост принудительно разорвал существующее подключение
LSP: V - header parse error: [WinError 10054] Удаленный хост принудительно разорвал существующее подключение
...
```

happens when tcp connection was reset by server. (like when server crashes)