### PR TITLE
better header parsing

### DIFF
--- a/language.py
+++ b/language.py
@@ -1731,11 +1731,16 @@ def parse_headers(fp, _class=HTTPMessage):
     """
     headers = []
     not_headers = []
+    headers_found = False
 
     while True:
         line = fp.readline(_MAXLINE + 1)
+        if not line:
+            break
 
-        if not line.lower().startswith(_SUPPORTED_HEADERS) and line not in (b'\r\n', b'\n', b''):
+        if line.lower().startswith(_SUPPORTED_HEADERS):
+            headers_found = True
+        if not headers_found:
             # skip unsupported lines (like 'echo' in batch files)
             not_headers.append(line)
             continue


### PR DESCRIPTION
consider this batch file for Java LSP.
minimized by me.

```bat
@echo off
echo.
echo Usage: jLSP.cmd CacheDir
echo where "CacheDir" is an absolute path to your data directory. eclipse.jdt.ls stores workspace specific information in it. This should be unique per workspace/project.
echo.

:: language server installation folder (adjust to suit)
set Directory=C:/Java/jdt-language-server
:: language server jar file (update based on version file of jar)
set JarFile=%Directory%/plugins/org.eclipse.equinox.launcher_1.6.400.v20210924-0641.jar
:: language server config folder location
set Config=%Directory%/config_win

set CacheDir=%~1
echo Directory: %Directory%
echo   JarFile: %JarFile%
echo    Config: %Config%
echo  CacheDir: %CacheDir%

java -Dosgi.bundles.defaultStartLevel=4 -Declipse.product=org.eclipse.jdt.ls.core.product -Dlog.level=ALL -noverify -Xmx1G -jar %JarFile% -configuration %Config% --add-modules=ALL-SYSTEM --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED -data %CacheDir%

```

with this PR it will correctly show lines like `echo.` on LSP panel (empty lines)
and it will keep parsing headers further (not crashing on `echo.` lines)

PS: and we better use this minimized version of .cmd file.
with command like: `"cmd_windows": ["C:\\Java\\jLSP.cmd", "./cache_for_proj1"]`


![image](https://user-images.githubusercontent.com/275333/198364151-7b8aad6f-e17b-43aa-b997-13ca67283874.png)
