### PR TITLE
fixed: default registerOptions was overwriting whole server-side registerOptions

### DIFF
--- a/language.py
+++ b/language.py
@@ -1381,12 +1381,14 @@ class ServerConfig:
     def on_register(self, dynreg):
         """ process dynamic registration request: RegisterMethodRequest
         """
+        # check for 'documentSelector' in registerOptions
+        # "If set to null the document selector provided on the client side will be used." (c) LSP spec
         reg: Registration
         for reg in dynreg.registrations:
-            if reg.registerOptions and 'documentSelector' not in reg.registerOptions:
-                reg.registerOptions['documentSelector'] = self._default_selector
-            else:
+            if not isinstance(reg.registerOptions, dict):
                 reg.registerOptions = self._default_opts
+            elif 'documentSelector' not in reg.registerOptions:
+                reg.registerOptions['documentSelector'] = self._default_selector
 
         self.capabs.extend(dynreg.registrations)
 


### PR DESCRIPTION
I was looking through the code (I wanted to know if I can implement new LSP feature)
and noticed a bug. it was my mistake. bad "if" statement conditions. fixed it.

basically, we need to do `reg.registerOptions = self._default_opts` **ONLY** when registerOptions is None(or empty).

this bug wasn't breaking anything right now. but it could break something in the future. so better to fix it early.