### PR TITLE
support for dots in lsp server settings

### DIFF
--- a/readme/history.txt
+++ b/readme/history.txt
@@ -1,3 +1,6 @@
+2022.11.18
++ add: support for dot-path notation in Server-specific options
+
 2022.10.28
 - fix: error detecting project dir if project has file(s) in its root
 - fix: macros TM_xxxx were not expanded in snippets

--- a/readme/readme.txt
+++ b/readme/readme.txt
@@ -93,6 +93,13 @@ b) project config myname.cuda-proj-lsp
     }
   }
 
+You can also use dot-path notation to specify sections in simple format:
+  ...
+  "settings": {
+    "python.analysis.typeCheckingMode": "off",
+  }
+  ...
+ 
 
 Plugin options
 --------------


### PR DESCRIPTION
now we can write:
```json
"settings": {
        "python.analysis.typeCheckingMode": "off",
        "python.analysis.cachingLevel": "None",
        "pylsp.plugins.flake8.enabled": true,
        "pylsp.plugins.flake8.ignore": ["E124"],
        "pylsp.plugins.pyflakes.enabled": false,
        "pylsp.plugins.pycodestyle.enabled": false,
        "pylsp.plugins.mccabe.enabled": false,
}
```

instead of:
```json
"settings": {
    "python.analysis": {
          "typeCheckingMode": "off",
        },
        "pylsp": {
            "plugins": {
                "flake8": {
                    "enabled": true,
                    "ignore": ["E124"]
                },
                "pyflakes": {
                    "enabled": false,
                },
                "pycodestyle": {
                    "enabled": false,
                },
                "mccabe": {
                    "enabled": false,
                },
            }
        },
}
```

both formats will work.