### PR TITLE
fix: "NoneType object is not iterable" (when autocomplete in virtual caret space)

### DIFF
--- a/language.py
+++ b/language.py
@@ -1499,7 +1499,7 @@ class CompletionMan:
         
         _carets = ed.get_carets()
         x0,y0,_,_ = _carets[0]
-        self.word = get_word(x0, y0)
+        self.word = get_word(x0, y0) or ('','')
 
     def filter(self, item, word):
         s1 = item.filterText if item.filterText else item.label


### PR DESCRIPTION
```python
  File "F:\MySSDPrograms\cudatext\py\cuda_lsp\language.py", line 1539, in prepare_complete
    if any(self.word):
TypeError: 'NoneType' object is not iterable
```

happens when trying to autocomplete in virtual caret space.