### PR TITLE
autocompletion fix for jedi-language-server

### DIFF
--- a/language.py
+++ b/language.py
@@ -1535,7 +1535,7 @@ class CompletionMan:
         
         has_brackets = all(b in text for b in '()')
         if is_bracket_follows and has_brackets: # remove "(params)" if bracket follows
-            text = re.sub('\([^)]*\);?$', '', text)
+            text = re.sub('\([^)]*\)(;|\$\d)?$', '', text)
             has_brackets = False
         lex = ed.get_prop(PROP_LEXER_FILE, '')
         
@@ -1894,6 +1894,7 @@ def debug_completion():
     tests.append( Test('~~P|layer()', (2,0,3,0), '~Player()', '~~Player()',                                 True,   True) ) # cpp
     tests.append( Test('~P|layer()', (1,0,2,0), '~Player()', '~Player()',                                    True,   True) ) # cpp
     tests.append( Test('_Analysis_m|ode_(wqe qwe qw)', (0,0,11,0), '_Analysis_mode_(${1:mode})', '_Analysis_mode_(wqe qwe qw)', False, True) ) # cpp
+    tests.append( Test("ed.set_tex|t_all('')", (3,0,15,0), 'set_text_all(${1:text})$0', "ed.set_text_all('')", True, True) ) # python (jedi-language-server)
     
     
     failed = 0


### PR DESCRIPTION
fix for case: `ed.set_tex|t_all('')` becomes `ed.set_text_all(text)('')`
jedi-language-server autocompletes funcs with snippets like `set_text_all(${1:text})$0`
we must account for "$0" to correctly remove "(text)"