### PR TITLE
presumption that didSave is supported by server (if textDocumentSync is a number)

### DIFF
--- a/language.py
+++ b/language.py
@@ -1343,6 +1343,9 @@ class ServerConfig:
                 if isinstance(_save, dict):
                     _opts.update(_save)
                 self.capabs.append(Registration(id='0', method=METHOD_DID_SAVE, registerOptions=_opts))
+        
+        if isinstance(docsync, int):
+            self.capabs.append(Registration(id='0', method=METHOD_DID_SAVE, registerOptions=self._default_opts))
 
         #  OPEN, CLOSE
         if is_openclose:


### PR DESCRIPTION
when textDocumentSync (in ServerCapabilities) is a number like this:

```json
"textDocumentSync": 2,
```

and not object like this:

```json
"textDocumentSync": { "openClose": true, "change": 2, "save": true },
```

we must presume that didSave is supported by server.