### PR TITLE
optimize diagnostics memo

### DIFF
--- a/dlg.py
+++ b/dlg.py
@@ -589,9 +589,9 @@ class PanelLog:
 
     def log(self, msg):   # events: ShowMessage, LogMessage
         severity_str = SEVERITY_MAP[msg.type.value]
-        self.log_str(msg.message, type_=type(msg), severity=severity_str)
+        self.log_str(msg.message, type_=type(msg), severity=severity_str, scroll=True)
 
-    def log_str(self, s, type_, severity=SEVERITY_NA):
+    def log_str(self, s, type_, severity=SEVERITY_NA, scroll=False):
         if s and s[-1] != '\n':
             s += '\n'
 
@@ -599,7 +599,7 @@ class PanelLog:
 
         self._msgs.append(lm)
         if self._filter_msg(lm):
-            self._append_memo_msg(lm)
+            self._append_memo_msg(lm, scroll=scroll)
 
         timer_proc(TIMER_START_ONE, self._update_counts, 500)
         self._update_sidebar()
@@ -641,10 +641,10 @@ class PanelLog:
     def _scroll_to_end(self, *args, **vargs):
         self._memo.cmd(cmds.cCommand_GotoTextEnd)
 
-    def _append_memo_msg(self, msg):
+    def _append_memo_msg(self, msg, scroll=False):
         _nline = self._memo_pos[1]
         newpos = self._memo.insert(*self._memo_pos, msg.msg)
-        self._scroll_to_end()
+        scroll and self._scroll_to_end()
 
         if newpos is not None:
             self._memo_pos = newpos

--- a/language.py
+++ b/language.py
@@ -1194,6 +1194,7 @@ class DiagnosticsMan:
                     ed.decor(DECOR_SET, line=nline, image=decor_im_map[decor_severity], text=tooltip, tag=DIAG_BM_TAG)
                 else:
                     ed.bookmark(BOOKMARK_SET, nline=nline, nkind=kind, text=text, tag=DIAG_BM_TAG)
+            self.logger._scroll_to_end()
             #end for line_diags
 
             # underline error text ranges


### PR DESCRIPTION
optimization: scroll diagnostics memo to end only when all diagnostics are added, not after every line.

tested on big (6527 lines) .lua file: https://raw.githubusercontent.com/Neutronic/ReaScripts/master/Utilities/Quick%20Adder%202/neutronic_Quick%20Adder%202.lua

(to reproduce slowness be sure to click on LSP icon first, to init LSP panel)

### measurments:
before 
```c
_apply_diagnostics 548
time:  0:00:00.930984
_apply_diagnostics 653
time:  0:00:01.165986
_apply_diagnostics 659
time:  0:00:01.162987
_apply_diagnostics 712
time:  0:00:01.282986
_apply_diagnostics 1236
time:  0:00:02.795999
```

after
```c
_apply_diagnostics 407
time:  0:00:00.168015
_apply_diagnostics 653
time:  0:00:00.394016
_apply_diagnostics 659
time:  0:00:00.402000
_apply_diagnostics 712
time:  0:00:00.465000
_apply_diagnostics 1236
time:  0:00:01.217000
```