### PR TITLE
better server response debug

### DIFF
--- a/language.py
+++ b/language.py
@@ -409,6 +409,12 @@ class Language:
                         err_str = err_str[:limit] + '...'
                     msg_status(f'{LOG_NAME}: {self.lang_str}: unsupported msg: {err_str}')
                     pass;       LOG and self.plog.log_str(f'{err}', type_='dbg', severity=SEVERITY_ERR)
+                    response_error_dict = err.args[0].dict()
+                    UnsupportedMessage = type('Unsupported Message!', (object,), {
+                        'dict':lambda _: response_error_dict,
+                        '__str__':lambda _: str(response_error_dict),
+                    })
+                    self._dbg_msgs = (self._dbg_msgs + [UnsupportedMessage()])[-512:]
 
                 errors.clear()
 


### PR DESCRIPTION
now unsupported messages will be shown in `LSP client: Debug: View server responses`

![cudatext_tSVn0I4FHq](https://user-images.githubusercontent.com/275333/231686806-22d4aa93-e357-4949-9497-28a5f7cc7a83.png)
