### PR TITLE
optimized autocompletion speed and debug log memory usage

### DIFF
--- a/book.py
+++ b/book.py
@@ -223,18 +223,21 @@ class EditorDoc:
 
     #def apply_edit(ed: Editor, edit: TextEdit):
     def apply_edit(ed, edit):
-        x1,y1,x2,y2 = EditorDoc.range2carets(edit.range)
+        x1,y1,x2,y2 = EditorDoc.range2carets(edit.get('range'))
         
         while ed.get_line_count() <= y2:
             ed.set_text_line(-2, '')
         
         if x1==x2 and y1==y2:
             #NOTE: need 'insert' because cant `replace()'` beyond text end
-            ed.insert(x1,y1, edit.newText)
+            ed.insert(x1,y1, edit.get('newText'))
         else:
-            ed.replace(x1,y1,x2,y2, edit.newText)
+            ed.replace(x1,y1,x2,y2, edit.get('newText'))
 
     def range2carets(range):
         #x1,y1,x2,y2
-        return (range.start.character, range.start.line,  range.end.character, range.end.line,)
+        return (range.get('start')['character'],
+                range.get('start')['line'],
+                range.get('end')['character'],
+                range.get('end')['line'])
 

--- a/sansio_lsp_client/client.py
+++ b/sansio_lsp_client/client.py
@@ -252,6 +252,7 @@ class Client:
 
         self._send_buf += _make_request(method=method, params=params, id=id)
         self._unanswered_requests[id] = Request(id=id, method=method, params=params)
+        
         return id
 
     def _send_notification(
@@ -300,7 +301,9 @@ class Client:
             completion_list = None
 
             try:
-                completion_list = CompletionList.parse_obj(response.result)
+                import time
+                #completion_list = CompletionList.parse_obj(response.result)
+                completion_list = response.result # because parse_obj is expensive and not really needed.
             except ValidationError:
                 try:
                     completion_list = CompletionList(
@@ -727,3 +730,4 @@ class Client:
             method="textDocument/rangeFormatting",
             params=params,
         )
+

--- a/sansio_lsp_client/events.py
+++ b/sansio_lsp_client/events.py
@@ -124,7 +124,8 @@ class WorkDoneProgressEnd(WorkDoneProgress):
 # XXX: should these two be just Events or?
 class Completion(Event):
     message_id: Id
-    completion_list: t.Optional[CompletionList]
+    #completion_list: t.Optional[CompletionList]
+    completion_list: t.Optional[t.Dict[str, t.Any]] # make it raw dict (optimization)
 
 
 # XXX: not sure how to name this event.


### PR DESCRIPTION
tested on tailwindcss lsp server.
it was very slow. it gives a lot of completion results (11k)

1. `parse_obj` method of `pydantic` library (used in cuda_lsp) is slow for 11k results (0.8 sec)
we can get rid of parsing dictionary to object and better use dictionary directly.

now instead of waiting for autocompletion listbox for 1.2-1.5 seconds we only wait 0.2-0.5

2. another optimization is disabling debug messages used by command `LSP client: Debug: Debug server responses`
11k results is storing there on every autocompletion call and keep on eating memory like crazy.
disabled debug messages, they are needed for devs, not for users.

@Alexey-T  please, see.