### PR TITLE
enable tagSupport for publishDiagnostics (diagnostics will bring more hints)

### DIFF
--- a/readme/history.txt
+++ b/readme/history.txt
@@ -1,3 +1,6 @@
+2024.01.08 (by @veksha)
++ add: enable tagSupport for publishDiagnostics (diagnostics will bring more hints)
+
 2023.12.25 (by @veksha)
 + add: in Goto References dialog, preselect item which is equal to current line
 

--- a/sansio_lsp_client/client.py
+++ b/sansio_lsp_client/client.py
@@ -88,7 +88,10 @@ CAPABILITIES = {
         },
 
         'publishDiagnostics': {
-            'relatedInformation': True
+            'relatedInformation': True,
+            'tagSupport': {
+                'valueSet': [1,2]
+            }
         },
 
         'completion': {


### PR DESCRIPTION
example: pyright will have more hints

![image](https://github.com/CudaText-addons/cuda_lsp/assets/275333/fc00c8a3-85f9-4896-aac7-ae1ca5d0a2b2)
