### PR TITLE
do not crash plugin on nimlangserver's bug related to WorkDoneProgress event

### DIFF
--- a/language.py
+++ b/language.py
@@ -1142,7 +1142,9 @@ class Language:
 
     def _on_progress(self, msg):
         if isinstance(msg, events.WorkDoneProgressCreate):
-            self.progresses[msg.token] = None
+            # on buggy servers token can already exist at this stage.
+            # such server bugs must be silently ignored without crashing our plugin.
+            self.progresses.setdefault(msg.token, None) # set to None ONLY if it desn't exist
             msg.reply()
 
         elif isinstance(msg, events.WorkDoneProgress):

--- a/readme/history.txt
+++ b/readme/history.txt
@@ -1,5 +1,6 @@
 2024.01.08 (by @veksha)
 + add: enable tagSupport for publishDiagnostics (diagnostics will bring more hints)
+- fix: do not crash plugin on nimlangserver's bug related to WorkDoneProgress event
 
 2023.12.25 (by @veksha)
 + add: in Goto References dialog, preselect item which is equal to current line

--- a/sansio_lsp_client/client.py
+++ b/sansio_lsp_client/client.py
@@ -435,6 +435,13 @@ class Client:
 
         elif request.method == "$/progress":
             progress_type = self._progress_tokens_map.get(request.params['token'])
+            
+            # if "window/workDoneProgress/create" request from server was missing -
+            # pretend it actually was already recieved. i think there is no harm in that.
+            # such server bugs must be silently ignored without crashing our plugin.
+            if progress_type is None:
+                self._progress_tokens_map[request.params['token']] = WorkDoneProgress
+                progress_type = WorkDoneProgress
 
             if progress_type == WorkDoneProgress:
                 kind = request.params['value']['kind']


### PR DESCRIPTION
crash:
```
LSP: Nim - unknown Message type: <class 'NoneType'>
ERROR: QueuesProcessingError: LSP: Nim - 'NoneType' object has no attribute 'value'
Traceback (most recent call last):
  File "F:\MySSDPrograms\cudatext\py\cuda_lsp\language.py", line 429, in process_queues
    self._on_lsp_msg(msg)
  File "F:\MySSDPrograms\cudatext\py\cuda_lsp\language.py", line 593, in _on_lsp_msg
    self._on_progress(msg)
  File "F:\MySSDPrograms\cudatext\py\cuda_lsp\language.py", line 1163, in _on_progress
    title = self.progresses.pop(msg.token).value.title # deletes start-message
AttributeError: 'NoneType' object has no attribute 'value'
```

this is because `workDoneProgressCreate` is called AFTER `progress`, but must be called before.
it is safe to ignore such bugs.