### PR TITLE
hover (hint) dialog height was calculated incorrectly for high DPI.

### DIFF
--- a/dlg.py
+++ b/dlg.py
@@ -167,8 +167,11 @@ class Hint:
         caret_loc_px = ed.convert(CONVERT_CARET_TO_PIXELS, x=caret[0], y=caret[1])
         top_hint = caret_loc_px[1]-t > b-caret_loc_px[1] # space up is larger than down
         y0,y1 = (t, caret_loc_px[1])  if top_hint else  (caret_loc_px[1], b)
-        h = min(FORM_H,  y1-y0 - FORM_GAP*2 - cell_h)
-        w = min(FORM_W, ed_size_x)
+        space_h = y1-y0 - FORM_GAP*2
+        if not top_hint:
+            space_h -= cell_h
+        h = min(FORM_H * _scale_UI_percent // 100, space_h)
+        w = min(FORM_W * _scale_UI_percent // 100, ed_size_x)
 
         x = caret_loc_px[0] - int(w*0.5) # center over caret
         if x < l: # dont fit on left
@@ -186,13 +189,13 @@ class Hint:
                 'p': ed.get_prop(PROP_HANDLE_SELF ), #set parent to Editor handle
                 'x': x,
                 'y': y,
-                'w': w * _scale_UI_percent // 100,
-                'h': h * _scale_UI_percent // 100,
+                'w': w,
+                'h': h,
                 })
 
         cls.caret_cmds = caret_cmds
         if caret_cmds:
-            cls.fill_cmds(caret_cmds, w)
+            cls.fill_cmds(caret_cmds, min(FORM_W, ed_size_x))
 
         # first - large delay, after - smaller
         timer_proc(TIMER_START_ONE, Hint.hide_check_timer, 750, tag='initial')

--- a/readme/history.txt
+++ b/readme/history.txt
@@ -1,3 +1,6 @@
+2024.01.23 (by @veksha)
+- fix: hover (hint) dialog height was calculated incorrectly for high DPI.
+
 2024.01.14 (by @veksha)
 - fix: some lsp servers can return None for certain values even when its against the LSP specs.
 


### PR DESCRIPTION
before fix:

https://github.com/CudaText-addons/cuda_lsp/assets/275333/9e0331ee-20c5-44db-9b9c-62dd6930d0da

after fix:
(tested on 96 and 150 dpi on linux)

https://github.com/CudaText-addons/cuda_lsp/assets/275333/53791227-006e-45d4-9a85-e674ce77ca90

rebooted to windows, tested -> ok.