### PR TITLE
- fix: force server shutdown if no response to shutdown request for 5…

### DIFF
--- a/lsp.py
+++ b/lsp.py
@@ -483,6 +483,9 @@ class Command:
                 self._do_on_open(editor)
 
         elif state == APPSTATE_PROJECT:
+            for name,lang in list(self._langs.items()):
+                lang.plog.clear()
+            
             new_project_dir = get_project_dir()
             if self._project_dir != new_project_dir  and  self._langs:
                 _collapsed_path = collapse_path(new_project_dir)
@@ -493,11 +496,14 @@ class Command:
                     if not handled:
                         self.shutdown_server(name=name)
 
-                # on_open visible eds/docs without lang
-                for edt in get_visible_eds():
-                    doc = self.book.get_doc(edt)
-                    if not doc  or  not doc.lang:
-                        self.on_open(edt)
+                ### == this code block can launch same server again after we triggered shutdown of it above.
+                ### == that's bad.
+                ## on_open visible eds/docs without lang
+                #for edt in get_visible_eds():
+                #    doc = self.book.get_doc(edt)
+                #    if not doc  or  not doc.lang:
+                #        self.on_open(edt)
+                ### ==
 
         elif state == APPSTATE_THEME_UI:
             from .dlg import PanelLog

--- a/readme/history.txt
+++ b/readme/history.txt
@@ -1,3 +1,8 @@
+2024.01.28 (by @veksha)
+- fix: force server shutdown if no response to shutdown request for 5 secs. (fix for nimlangserver)
+- fix: commented out block of code that can launch the same server again just after we triggered shutdown of it. happens on project switching.
++ add: clear all LSP bottom panel info before opening another project
+
 2024.01.27 (by @veksha)
 + add: do not hide the Hover window while the user is holding the mouse button and if the user releases the button, provide an opportunity for him to return the cursor to the window.
 


### PR DESCRIPTION
… secs. (fix for nimlangserver)

- fix: commented out block of code that can launch the same server again just after we triggered shutdown of it. happens on project switching.
+ add: clear all LSP bottom panel info before opening another project