### PR TITLE
Fix OmniSharp Go To Definition

### DIFF
--- a/sansio_lsp_client/client.py
+++ b/sansio_lsp_client/client.py
@@ -40,6 +40,7 @@ from .events import (
     WorkDoneProgressEnd,
     ConfigurationRequest,
     WorkspaceFolders,
+    Metadata,
 )
 from .structs import (
     Response,
@@ -382,6 +383,9 @@ class Client:
         # WORKSPACE
         elif request.method == "workspace/symbol":
             event = parse_obj_as(MWorkspaceSymbols, response)
+
+        elif request.method == "o#/metadata":
+            event = Metadata(message_id=response.id, result=response.result)
 
         else:
             raise NotImplementedError((response, request))
@@ -747,4 +751,7 @@ class Client:
             method="textDocument/rangeFormatting",
             params=params,
         )
+
+    def metadata(self, params):
+        return self._send_request(method="o#/metadata", params=params)
 

--- a/sansio_lsp_client/events.py
+++ b/sansio_lsp_client/events.py
@@ -1,6 +1,7 @@
 import typing as t
 
 from pydantic import BaseModel, PrivateAttr
+from typing import Optional, Dict, Any
 
 if t.TYPE_CHECKING:  # avoid import cycle at runtime
     from .client import Client
@@ -263,3 +264,7 @@ class ConfigurationRequest(ServerRequest):
     def reply(self, result=t.List[t.Any]) -> None:
         self._client._send_response(id=self._id,  result=result)
 
+class Metadata(Event):
+    message_id: int
+    result: Optional[Dict[str, Any]] = None
+    


### PR DESCRIPTION
### Add support for OmniSharp metadata URIs to fetch decompiled .NET source code

#### Summary
actually **Go To Definition** for C# using OmniSharp is broken, OmniSharp prints “file not found” `file:///$metadata$/Project/mytool/Assembly/System/Runtime/Symbol/System/IO/File.cs`.
This happens because `$metadata$...` files are **virtual** metadata documents created by OmniSharp (they're not real files on disk), and CudaText's LSP client is trying to treat them as ordinary filesystem paths — so it fails with “file not found”

#### Details

This PR adds support for handling virtual metadata URIs returned by OmniSharp (the C# LSP server) during "go to definition" for .NET framework classes. OmniSharp uses a [non-standard LSP extension](https://github.com/OmniSharp/omnisharp-roslyn/issues/2238): instead of returning a real file path, it provides a virtual URI like `file:///$metadata$/Project/{project}\\Assembly/{assembly}\\Symbol/{namespace}/{type}.cs`. To retrieve the actual decompiled source code, a custom LSP request (`o#/metadata`) must be sent with parsed parameters (`ProjectName, AssemblyName, TypeName`). The response contains the source code, which is then opened in a new unsaved tab in CudaText, scrolled to the target position.

#### Changes

1. **sansio_lsp_client/events.py**:
    - Added a new `Metadata `event class (simple Pydantic model inheriting from `Event`) to handle responses from the custom `o#/metadata` method.
2. **sansio_lsp_client/client.py**:
    - Imported the new `Metadata `event.
    - Added handling for `request.method == "o#/metadata"` in `_handle_response`: Creates a Metadata event with the response result.
    - Added a convenience method `def metadata(self, params)` that calls `_send_request("o#/metadata", params=params)`, mirroring the pattern used for standard methods like `hover `or `definition`.
3. **language.py**:
    - In `__init__`: Added `self.metadata_goto_requests = {}` to store pending metadata requests (ID -> `(reqpos, targetrange, dlg_caption)`).
    - In `_on_lsp_msg`:
        - Added handler for `msgtype == events.Metadata`: Retrieves stored data and calls `_handle_metadata `with the result.
        - Extended the existing `ResponseError `handler to also log errors for metadata requests (pops from `metadata_goto_requests `if present).
    - Added `def _handle_metadata(self, result, targetrange, reqpos, dlg_caption)`: Extracts Source and `SourceName `from the result, opens a new unsaved tab with the decompiled code (sets title and C# lexer), positions the caret/scroll to the target range.
    - In `do_goto`:
        - Detects metadata URIs (`uri.startswith('file:///%24metadata%24')`).
        - Parses the URI path (unquotes, splits by `\`, extracts `ProjectName, AssemblyName, TypeName`).
        - Sends `self.client.metadata(params)` with the parsed params.
        - Stores the request ID in `metadata_goto_requests `and calls `self.process_queues()` to flush.
        - Returns early (async handling).

No changes to other files. The code assumes decompilation (`enableDecompilationSupport`) is enabled in OmniSharp's `omnisharp.json` for full source; otherwise, it falls back to metadata declarations.

#### How It Works

- When OmniSharp returns a metadata URI in a "go to definition" response (e.g., for `System.IO.File`), `do_goto `intercepts it.
- URI parsing example: `file:///$metadata$/Project/mytool/Assembly/System/Runtime/Symbol/System/IO/File.cs` → `ProjectName="mytool", AssemblyName="System.Runtime", TypeName="System.IO.File"`.
- Sends custom request: `{"Timeout": 2000, "ProjectName": "...", "AssemblyName": "...", "TypeName": "..."}`.
- On response (`Metadata `event): Opens decompiled source in a new tab (e.g., titled "System.IO.File.cs"), sets lexer to "C#", jumps to the symbol position (with 3-line scroll padding).
- Errors (e.g., timeout, invalid parse) are logged via `plog `and status bar.

This replicates the async request pattern used for standard LSP methods (e.g., `self.client.definition(...)` → `Definition `event → handled in `_on_lsp_msg`).

#### Testing

- Tested with OmniSharp on a C# project referencing .NET framework assemblies (e.g., `System.IO.File`).
- Go to definition opens decompiled source correctly.
- No regressions on other LSP servers (e.g., Python).

Closes https://github.com/CudaText-addons/cuda_lsp/issues/214 