### PR TITLE
fix OmniSharp Go To Definition - fix1

### DIFF
--- a/language.py
+++ b/language.py
@@ -1005,8 +1005,8 @@ class Language:
         target_line = max(0, targetrange.start.line - 3)
         target_caret = (targetrange.start.character, targetrange.start.line)
         ed.set_caret(*target_caret)
-        ed.set_prop(PROP_LINE_TOP, target_line)
         app_idle(True)  # Ensure scroll and focus
+        ed.set_prop(PROP_LINE_TOP, target_line)
         
     def do_goto(self, items, dlg_caption, skip_dlg=False, reqpos=None):
         """ items: Location or t.List[t.Union[Location, LocationLink]], None


### PR DESCRIPTION
a small fix for OmniSharp Go To Definition: scroll to the returned line was not precise, `app_idle(True)` needs to be called before `ed.set_prop()`