### PR TITLE
Feature: Enhance Autocomplete with Fuzzy Matching, Improved Sorting, and Highlighting

### DIFF
--- a/language.py
+++ b/language.py
@@ -1963,6 +1963,7 @@ class CompletionMan:
             print(f"ERROR: failed {type_str} {test.lexer}: {test.initial_text} ===> {line} (must be {test.result_text})")
             return False
 
+    @staticmethod
     def _completion_fuzzy_match(stext, sfind):
         """
         Performs a fuzzy match check. ported from cuda_complete_from_text to have the same user experience inside CudaText
@@ -2012,7 +2013,7 @@ class CompletionMan:
                 return True
                 
             # If substring fails, try fuzzy matching
-            positions = _completion_fuzzy_match(s1, s2)
+            positions = CompletionMan._completion_fuzzy_match(s1, s2)
             if positions is not None:
                 # Store the match positions on the item for the highlighter
                 item['_cudalsp_fuzzy'] = positions 


### PR DESCRIPTION

### Description

I've refactored the `CompletionMan` class in `language.py` to improve the autocompletion user experience.

These changes introduce **fuzzy matching** (in addition to the existing substring matching), and **character-level highlighting** for fuzzy matches, similar to the experience in editors like VS Code.

this is how it looks now:
<img width="884" height="357" alt="image" src="https://github.com/user-attachments/assets/07c3a119-cb2e-4082-9bfd-124107d9a709" />


### Summary of Changes

Here is a detailed breakdown of the modifications:

#### 1\. Fuzzy Matching in `CompletionMan.filter`

- A new helper function, `_completion_fuzzy_match`, has been added. This logic is ported from `cuda_complete_from_text` to ensure a consistent fuzzy-matching experience across CudaText plugins.
    
- The `filter` method now implements a multi-stage check:
    
    1. It first attempts a fast, case-insensitive **substring** match (the previous behavior).
        
    2. If no substring match is found, it falls back to the new **fuzzy match** logic.
        
- To enable the new highlighting, the filter now stores the positions of matched characters (from the fuzzy match) in a temporary `_cudalsp_fuzzy` key on the completion item.
    

#### 2\. Improved Sorting in `CompletionMan.sort`

- The `sort` method has been updated to account for the new match types.
    
- The new sort priority is:
    
    1. Exact Match (case-sensitive)
        
    2. Exact Match (case-insensitive)
        
    3. Prefix Match (case-sensitive)
        
    4. Prefix Match (case-insensitive)
        
    5. **Substring Match** (new priority)
        
    6. **Fuzzy Match** (new priority)
        
    7. Server-provided `sortText` / Alphabetical
        

#### 3\. Character-Level Highlighting in `CompletionMan.show_complete`

- The `add_html_tags` helper function (inside `show_complete`) has been completely rewritten.
    
- Instead of only highlighting the first substring, it now reads the match positions (from `_cudalsp_fuzzy` or a new substring search) and builds an HTML string that **highlights only the matched characters**.
    
- This means a fuzzy search for `"fn"` on `"functionName"` will now correctly highlight just the `f` and `n`.
    

#### 4\. Bug Fix: Deprecated Item Detection
- Fixed a bug in the `is_deprecated` helper function (inside `show_complete`):

Some servers (TypeScript) use `sortText` starting with 'z' to mark deprecated items. But **python-lsp/python-lsp-server** server use 'z' to mark **Python builtins** ([src](https://github.com/python-lsp/python-lsp-server/blob/6a24326890964b56b8349b605ed76727f3502326/pylsp/plugins/jedi_completion.py#L315)). Previously, any completion item with `sortText` starting with `'z'` was marked as deprecated. This incorrectly flagged Python builtins and shows them as deprecated:
<img width="740" height="132" alt="image" src="https://github.com/user-attachments/assets/e14b40e3-b1bc-478a-973d-d45a69f4afff" />

- The fix adds a check (`is_typescript_server`) to ensure this `sortText.startswith('z')` rule is **only applied to JavaScript/TypeScript servers**, as intended.
________________________________________
this PR fixes: https://github.com/Alexey-T/CudaText/issues/5511 and 
 https://github.com/Alexey-T/CudaText/discussions/5455#discussioncomment-14908946